### PR TITLE
Fix permissions

### DIFF
--- a/controllers/accesses_controller.js
+++ b/controllers/accesses_controller.js
@@ -4,7 +4,7 @@ const log = require('../helpers/logging');
 const { accessesPath } = require('../routes/helpers/accesses');
 const { forumPath } = require('../routes/helpers/forums');
 
-// Handles the CRUD of group accesss with a forum
+// Handles the CRUD of group accesses for a forum
 exports.edit = (req, res, next) => {
   const { semester_name, module_code, title } = req.params;
   db.query(sql.groups.queries.get_groups_by_course, [semester_name, module_code], (err1, data1) => {

--- a/controllers/courses_controller.js
+++ b/controllers/courses_controller.js
@@ -1,6 +1,9 @@
 const db = require('../db');
 const sql = require('../sql');
 const log = require('../helpers/logging');
+const { canShowCourse, canCreateCourse, canUpdateCourse, canDeleteCourse } = require('../permissions/courses');
+const { canCreateForum, canUpdateForum, canDeleteForum } = require('../permissions/forums');
+const { canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissions/groups');
 const { coursesPath, courseNewPath, courseEditPath } = require('../routes/helpers/courses');
 
 exports.index = (req, res, next) => {

--- a/controllers/courses_controller.js
+++ b/controllers/courses_controller.js
@@ -7,7 +7,7 @@ const { canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissio
 const { coursesPath, courseNewPath, courseEditPath } = require('../routes/helpers/courses');
 
 exports.index = async (req, res, next) => {
-  const { semester_name, module_code } = req.params;
+  const { semester_name, module_code } = req.query;
   const permissions = {
     can_create_course: await canCreateCourse(req.user),
     can_delete_course: await canDeleteCourse(req.user)

--- a/controllers/courses_controller.js
+++ b/controllers/courses_controller.js
@@ -1,20 +1,24 @@
 const db = require('../db');
 const sql = require('../sql');
 const log = require('../helpers/logging');
-const { canShowCourse, canCreateCourse, canUpdateCourse, canDeleteCourse } = require('../permissions/courses');
+const { canCreateCourse, canDeleteCourse } = require('../permissions/courses');
 const { canCreateForum, canUpdateForum, canDeleteForum } = require('../permissions/forums');
 const { canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissions/groups');
 const { coursesPath, courseNewPath, courseEditPath } = require('../routes/helpers/courses');
 
-exports.index = (req, res, next) => {
-  const { semester_name, module_code } = req.query;
+exports.index = async (req, res, next) => {
+  const { semester_name, module_code } = req.params;
+  const permissions = {
+    can_create_course: await canCreateCourse(req.user),
+    can_delete_course: await canDeleteCourse(req.user)
+  };
   if (semester_name) {
     db.query(sql.courses.queries.get_courses_by_semester, [semester_name], (err, data) => {
       if (err) {
         log.error(`Failed to get courses offered in ${semester_name}`);
         next(err);
       } else {
-        res.render('courses', { data: data.rows, title: `Courses offered in ${semester_name}` });
+        res.render('courses', { data: data.rows, title: `Courses offered in ${semester_name}`, permissions });
       }
     });
   } else if (module_code) {
@@ -23,7 +27,7 @@ exports.index = (req, res, next) => {
         log.error(`Failed to get courses for ${module_code}`);
         next(err);
       } else {
-        res.render('courses', { data: data.rows, title: `Courses for module ${module_code}` });
+        res.render('courses', { data: data.rows, title: `Courses for module ${module_code}`, permissions });
       }
     });
   } else {
@@ -32,14 +36,22 @@ exports.index = (req, res, next) => {
         log.error('Failed to get courses');
         next(err);
       } else {
-        res.render('courses', { data: data.rows, title: 'All courses' });
+        res.render('courses', { data: data.rows, title: 'All courses', permissions });
       }
     });
   }
 };
 
-exports.show = (req, res, next) => {
+exports.show = async (req, res, next) => {
   const { semester_name, module_code } = req.params;
+  const permissions = {
+    can_create_group: await canCreateGroup(req.user, semester_name, module_code),
+    can_update_group: await canUpdateGroup(req.user, semester_name, module_code),
+    can_delete_group: await canDeleteGroup(req.user, semester_name, module_code),
+    can_create_forum: await canCreateForum(req.user, semester_name, module_code),
+    can_update_forum: await canUpdateForum(req.user, semester_name, module_code),
+    can_delete_forum: await canDeleteForum(req.user, semester_name, module_code)
+  };
   db.query(sql.courses.queries.find_course, [semester_name, module_code], (err1, data1) => {
     if (err1) {
       log.error(`Failed to get course ${module_code} offered in ${semester_name}`);
@@ -56,7 +68,7 @@ exports.show = (req, res, next) => {
               log.error(`Failed to get forums of ${module_code} offered in ${semester_name}`);
               next(err3);
             } else {
-              res.render('course', { course, groups: data2.rows, forums: data3.rows });
+              res.render('course', { course, groups: data2.rows, forums: data3.rows, permissions });
             }
           });
         }

--- a/controllers/forums_controller.js
+++ b/controllers/forums_controller.js
@@ -4,9 +4,16 @@ const log = require('../helpers/logging');
 const { coursePath } = require('../routes/helpers/courses');
 const { forumPath } = require('../routes/helpers/forums');
 const { findCourse, findForum } = require('./helpers/index');
+const { canEditAccess } = require('../permissions/accesses');
+const { canEditThread, canDeleteThreads } = require('../permissions/threads');
 
 exports.show = async (req, res, next) => {
   const { semester_name, module_code, title: forum_title } = req.params;
+  const permissions = {
+    can_edit_access: await canEditAccess(req.user, semester_name, module_code),
+    can_edit_thread: await canEditThread(req.user, semester_name, module_code),
+    can_delete_thread: await canDeleteThreads(req.user, semester_name, module_code)
+  };
   try {
     const course = await findCourse(req, semester_name, module_code);
     const forum = await findForum(req, semester_name, module_code, forum_title);
@@ -29,7 +36,7 @@ exports.show = async (req, res, next) => {
         }
       );
 
-    res.render('forum', { course, forum, threads, group_names });
+    res.render('forum', { course, forum, threads, group_names, permissions });
   } catch (err) {
     req.flash('error', err.message);
     next(err);

--- a/controllers/forums_controller.js
+++ b/controllers/forums_controller.js
@@ -5,14 +5,14 @@ const { coursePath } = require('../routes/helpers/courses');
 const { forumPath } = require('../routes/helpers/forums');
 const { findCourse, findForum } = require('./helpers/index');
 const { canEditAccess } = require('../permissions/accesses');
-const { canEditThread, canDeleteThreads } = require('../permissions/threads');
+const { canEditThread, canDeleteThread } = require('../permissions/threads');
 
 exports.show = async (req, res, next) => {
   const { semester_name, module_code, title: forum_title } = req.params;
   const permissions = {
     can_edit_access: await canEditAccess(req.user, semester_name, module_code),
     can_edit_thread: await canEditThread(req.user, semester_name, module_code),
-    can_delete_thread: await canDeleteThreads(req.user, semester_name, module_code)
+    can_delete_thread: await canDeleteThread(req.user, semester_name, module_code)
   };
   try {
     const course = await findCourse(req, semester_name, module_code);

--- a/controllers/helpers/index.js
+++ b/controllers/helpers/index.js
@@ -5,34 +5,31 @@ const log = require('../../helpers/logging');
 function findCourse(req, semester_name, module_code) {
   return db
     .query(sql.courses.queries.find_course, [semester_name, module_code])
-    .catch(err => {
+    .then(data => data.rows[0], err => {
       log.error(`Failed to get course ${semester_name} ${module_code}`);
       req.flash('error', err.message);
       throw err;
-    })
-    .then(data => data.rows[0]);
+    });
 }
 
 function findForum(req, semester_name, module_code, forum_title) {
   return db
     .query(sql.forums.queries.find_forum, [semester_name, module_code, forum_title])
-    .catch(err => {
+    .then(data => data.rows[0], err => {
       log.error(`Failed to get forum ${forum_title} of ${semester_name} ${module_code}`);
       req.flash('error', err.message);
       throw err;
-    })
-    .then(data => data.rows[0]);
+    });
 }
 
 function findThread(req, semester_name, module_code, forum_title, created_at) {
   return db
     .query(sql.threads.queries.find_thread, [semester_name, module_code, forum_title, created_at])
-    .catch(err => {
+    .then(data => data.rows[0], err => {
       log.error(`Failed to get thread created at ${created_at} for ${semester_name} ${module_code}`);
       req.flash('error', err.message);
       throw err;
-    })
-    .then(data => data.rows[0]);
+    });
 }
 
 module.exports = {

--- a/controllers/helpers/index.js
+++ b/controllers/helpers/index.js
@@ -3,33 +3,38 @@ const sql = require('../../sql');
 const log = require('../../helpers/logging');
 
 function findCourse(req, semester_name, module_code) {
-  return db
-    .query(sql.courses.queries.find_course, [semester_name, module_code])
-    .then(data => data.rows[0], err => {
+  return db.query(sql.courses.queries.find_course, [semester_name, module_code]).then(
+    data => data.rows[0],
+    err => {
       log.error(`Failed to get course ${semester_name} ${module_code}`);
       req.flash('error', err.message);
       throw err;
-    });
+    }
+  );
 }
 
 function findForum(req, semester_name, module_code, forum_title) {
-  return db
-    .query(sql.forums.queries.find_forum, [semester_name, module_code, forum_title])
-    .then(data => data.rows[0], err => {
+  return db.query(sql.forums.queries.find_forum, [semester_name, module_code, forum_title]).then(
+    data => data.rows[0],
+    err => {
       log.error(`Failed to get forum ${forum_title} of ${semester_name} ${module_code}`);
       req.flash('error', err.message);
       throw err;
-    });
+    }
+  );
 }
 
 function findThread(req, semester_name, module_code, forum_title, created_at) {
   return db
-    .query(sql.threads.queries.find_thread, [semester_name, module_code, forum_title, created_at])
-    .then(data => data.rows[0], err => {
-      log.error(`Failed to get thread created at ${created_at} for ${semester_name} ${module_code}`);
-      req.flash('error', err.message);
-      throw err;
-    });
+    .query(sql.threads.queries.find_thread_with_author_name, [semester_name, module_code, forum_title, created_at])
+    .then(
+      data => data.rows[0],
+      err => {
+        log.error(`Failed to get thread created at ${created_at} for ${semester_name} ${module_code}`);
+        req.flash('error', err.message);
+        throw err;
+      }
+    );
 }
 
 module.exports = {

--- a/controllers/replies_controller.js
+++ b/controllers/replies_controller.js
@@ -88,7 +88,7 @@ exports.update = async (req, res, next) => {
       content
     ]).then(
       () => {
-        req.flash('success', `Successfully updated reply posted at ${posted_at}`);
+        req.flash('success', `Successfully updated reply posted at ${posted_at}!`);
         res.redirect(threadPath(semester_name, module_code, forum_title, parseDbFormTimestamp(thread_created_at)));
       },
       err => {
@@ -98,7 +98,7 @@ exports.update = async (req, res, next) => {
       }
     );
   } catch (err) {
-    res.flash(err.message);
+    req.flash('error', err.message);
     next(err);
   }
 };
@@ -106,13 +106,15 @@ exports.update = async (req, res, next) => {
 exports.delete = (req, res) => {
   const { semester_name, module_code, title: forum_title, created_at: thread_created_at, posted_at } = req.params;
   db.query(sql.replies.queries.delete_reply, [semester_name, module_code, forum_title, thread_created_at, posted_at])
-    .then(() => {
-      req.flash('success', `Successfully deleted reply posted at ${posted_at}!`);
-    })
-    .catch(err => {
-      log.error(`Failed to delete reply posted at ${posted_at}`);
-      req.flash('error', err.message);
-    })
+    .then(
+      () => {
+        req.flash('success', `Successfully deleted reply posted at ${posted_at}!`);
+      },
+      err => {
+        log.error(`Failed to delete reply posted at ${posted_at}`);
+        req.flash('error', err.message);
+      }
+    )
     .then(() => {
       res.redirect(threadPath(semester_name, module_code, forum_title, parseDbFormTimestamp(thread_created_at)));
     });

--- a/controllers/threads_controller.js
+++ b/controllers/threads_controller.js
@@ -41,11 +41,11 @@ exports.create = async (req, res, next) => {
         res.render('threadForm', { course, forum, thread: { title, content } });
       })
       .then(() => {
-        req.flash('success', `Successfully created thread ${title} in forum ${forum_title}`);
+        req.flash('success', `Successfully created thread ${title} in forum ${forum_title}!`);
         res.redirect(threadPath(semester_name, module_code, forum_title, created_at));
       });
   } catch (err) {
-    req.flash(err.message);
+    req.flash('error', err.message);
     next(err);
   }
 };
@@ -70,7 +70,7 @@ exports.show = async (req, res, next) => {
         );
         throw err;
       });
-      res.render('thread', { course, forum, thread, replies, permissions });
+    res.render('thread', { course, forum, thread, replies, permissions });
   } catch (err) {
     req.flash('error', err.message);
     next(err);

--- a/controllers/threads_controller.js
+++ b/controllers/threads_controller.js
@@ -5,6 +5,7 @@ const { forumPath } = require('../routes/helpers/forums');
 const { timestampToDbForm, parseDbFormTimestamp } = require('../helpers/date');
 const { threadPath } = require('../routes/helpers/threads');
 const { findCourse, findForum, findThread } = require('./helpers');
+const { canCreateReply, canUpdateReply, canDeleteReply } = require('../permissions/replies');
 
 exports.new = async (req, res, next) => {
   const { semester_name, module_code, title: forum_title } = req.params;
@@ -52,20 +53,16 @@ exports.create = async (req, res, next) => {
 exports.show = async (req, res, next) => {
   const { semester_name, module_code, title: forum_title, created_at: thread_created_at } = req.params;
   try {
+    const permissions = {
+      can_create_reply: await canCreateReply(req.user, semester_name, module_code, forum_title),
+      can_update_reply: await canUpdateReply(req.user, semester_name, module_code),
+      can_delete_reply: await canDeleteReply(req.user, semester_name, module_code)
+    };
     const course = await findCourse(req, semester_name, module_code);
     const forum = await findForum(req, semester_name, module_code, forum_title);
     const thread = await findThread(req, semester_name, module_code, forum_title, thread_created_at);
-    await db
-      .query(sql.users.queries.find_user_by_id, [thread.author_id])
-      .then(data => Object.assign(thread, { author_name: data.rows.length >= 1 ? data.rows[0].name : null }))
-      .catch(err => {
-        log.error(
-          `Failed to get author name for thread "${thread.title}" in forum "${forum.title} of ${semester_name} ${module_code}`
-        );
-        throw err;
-      });
     const replies = await db
-      .query(sql.replies.queries.get_replies_of_forum, [semester_name, module_code, forum_title, thread_created_at])
+      .query(sql.replies.queries.get_replies_of_thread, [semester_name, module_code, forum_title, thread_created_at])
       .then(data => data.rows)
       .catch(err => {
         log.error(
@@ -73,28 +70,7 @@ exports.show = async (req, res, next) => {
         );
         throw err;
       });
-    const allRepliesProcessed = replies.map(async reply => {
-      const author = await db
-        .query(sql.users.queries.find_user_by_id, [reply.author_id])
-        .then(data => (data.rows.length >= 1 ? data.rows[0] : null))
-        .catch(err => {
-          log.error(
-            `Failed to get author of reply posted at ${reply.created_at} in thread ${thread.title} in forum ${forum.title} of ${semester_name} ${module_code}`
-          );
-          throw err;
-        });
-      Object.assign(reply, {
-        author_name: author.name
-      });
-    });
-    Promise.all(allRepliesProcessed).then(() =>
-      res.render('thread', {
-        course,
-        forum,
-        thread,
-        replies
-      })
-    );
+      res.render('thread', { course, forum, thread, replies, permissions });
   } catch (err) {
     req.flash('error', err.message);
     next(err);

--- a/controllers/threads_controller.js
+++ b/controllers/threads_controller.js
@@ -34,16 +34,17 @@ exports.create = async (req, res, next) => {
       content,
       author_id
     ])
-      .then(() => {
-        req.flash('success', `Successfully created thread ${title} in forum ${forum_title}`);
-        res.redirect(threadPath(semester_name, module_code, forum_title, created_at));
-      })
       .catch(err => {
         log.error(`Failed to create thread ${title} in ${forum_title} of ${semester_name} ${module_code}`);
         req.flash('error', err.message);
         res.render('threadForm', { course, forum, thread: { title, content } });
+      })
+      .then(() => {
+        req.flash('success', `Successfully created thread ${title} in forum ${forum_title}`);
+        res.redirect(threadPath(semester_name, module_code, forum_title, created_at));
       });
   } catch (err) {
+    req.flash(err.message);
     next(err);
   }
 };
@@ -86,7 +87,14 @@ exports.show = async (req, res, next) => {
         author_name: author.name
       });
     });
-    Promise.all(allRepliesProcessed).then(() => res.render('thread', { course, forum, thread, replies }));
+    Promise.all(allRepliesProcessed).then(() =>
+      res.render('thread', {
+        course,
+        forum,
+        thread,
+        replies
+      })
+    );
   } catch (err) {
     req.flash('error', err.message);
     next(err);

--- a/controllers/users_controller.js
+++ b/controllers/users_controller.js
@@ -22,7 +22,7 @@ exports.delete = (req, res) => {
       req.flash('error', err.message);
       res.redirect('/users');
     } else if (req.user.id === id) {
-      // Log out the user during self-deletion
+      // Log out the user after self-deletion
       req.logout();
       req.flash('success', 'Your account has been successfully deleted. You have been logged out.');
       res.redirect('/');

--- a/permissions/accesses.js
+++ b/permissions/accesses.js
@@ -1,7 +1,7 @@
-const { isAdmin, isProfessorInCourse } = require('./helpers');
+const { passedAny, isAdmin, isProfessorInCourse } = require('./helpers');
 
 function canEditAccess(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 module.exports = {

--- a/permissions/courses.js
+++ b/permissions/courses.js
@@ -1,4 +1,4 @@
-const { isAdmin, isInCourse, isProfessorInCourse } = require('./helpers');
+const { passedAny, isAdmin, isInCourse, isProfessorInCourse } = require('./helpers');
 
 // Everyone can index courses
 
@@ -7,11 +7,11 @@ function canCreateCourse(user) {
 }
 
 function canShowCourse(user, semester_name, module_code) {
-  return isAdmin(user) || isInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isInCourse(user, semester_name, module_code));
 }
 
 function canUpdateCourse(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 function canDeleteCourse(user) {

--- a/permissions/forums.js
+++ b/permissions/forums.js
@@ -1,25 +1,25 @@
-const { isAdmin, isInForum, isProfessorInCourse } = require('./helpers');
+const { passedAny, isAdmin, isInForum, isProfessorInCourse } = require('./helpers');
 
 function canCreateForum(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 // TODO: to decide whether to allow ta access all forums
 // Currently TA can only access forums that can be accessed by their assigned groups
 function canShowForum(user, semester_name, module_code, forum_title) {
-  return (
-    isAdmin(user) ||
-    isProfessorInCourse(user, semester_name, module_code) ||
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
     isInForum(user, semester_name, module_code, forum_title)
   );
 }
 
 function canUpdateForum(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 function canDeleteForum(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 module.exports = {

--- a/permissions/groups.js
+++ b/permissions/groups.js
@@ -1,25 +1,25 @@
-const { isAdmin, isInGroup, isProfessorInCourse } = require('./helpers');
+const { passedAny, isAdmin, isInGroup, isProfessorInCourse } = require('./helpers');
 
 function canCreateGroup(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 // TODO: to decide whether to allow ta access all groups
 // Currently TA can only access their assigned groups
 function canShowGroup(user, semester_name, module_code, group_name) {
-  return (
-    isAdmin(user) ||
-    isProfessorInCourse(user, semester_name, module_code) ||
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
     isInGroup(user, semester_name, module_code, group_name)
   );
 }
 
 function canUpdateGroup(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 function canDeleteGroup(user, semester_name, module_code) {
-  return isAdmin(user) || isProfessorInCourse(user, semester_name, module_code);
+  return passedAny(isAdmin(user), isProfessorInCourse(user, semester_name, module_code));
 }
 
 module.exports = {

--- a/permissions/helpers.js
+++ b/permissions/helpers.js
@@ -3,66 +3,52 @@ const course_memberships = require('../sql/course_memberships');
 const group_memberships = require('../sql/group_memberships');
 const accesses = require('../sql/accesses');
 
-exports.isAdmin = user => user.is_admin;
+/* Util methods */
+// Checks if all checks have passed
+exports.passedAll = (...checks) => {
+  return Promise.all(checks).then(results => results.every(result => result));
+};
 
-exports.isSameUserID = (userID1, userID2) => userID1 === userID2;
+// Checks if any check has passed
+exports.passedAny = (...checks) => {
+  return Promise.all(checks).then(results => results.some(result => result));
+};
 
-exports.isInCourse = (user, semester_name, module_code) =>
-  db.query(course_memberships.queries.find_membership, [semester_name, module_code, user.id], (err, data) => {
-    if (err) {
-      throw new Error(err.message);
-    } else {
-      return data.rows.length === 1;
-    }
-  });
+/* Checkers */
+/* All checkers should return promises that resolve to boolean values */
+exports.isAdmin = async user => user.is_admin;
+
+exports.isSameUserID = async (userID1, userID2) => userID1 === userID2;
+
+exports.isInCourse = (user, semester_name, module_code) => {
+  return db
+    .query(course_memberships.queries.find_membership, [semester_name, module_code, user.id])
+    .then(data => data.rows.length === 1);
+};
 
 // Professors are not in any groups
-exports.isInGroup = (user, semester_name, module_code, group_name) =>
-  db.query(
-    group_memberships.queries.find_membership,
-    [semester_name, module_code, group_name, user.id],
-    (err, data) => {
-      if (err) {
-        throw new Error(err.message);
-      } else {
-        return data.rows.length === 1;
-      }
-    }
-  );
+exports.isInGroup = (user, semester_name, module_code, group_name) => {
+  return db
+    .query(group_memberships.queries.find_membership, [semester_name, module_code, group_name, user.id])
+    .then(data => data.rows.length === 1);
+};
 
 // Professors are not in any forums
-exports.isInForum = (user, semester_name, module_code, forum_title) =>
-  db.query(accesses.queries.find_access, [semester_name, module_code, forum_title, user.id], (err, data) => {
-    if (err) {
-      throw new Error(err.message);
-    } else {
-      // A user can be granted access multiple times (in multiple groups that have access to the same forum)
-      return data.rows.length >= 1;
-    }
-  });
+exports.isInForum = (user, semester_name, module_code, forum_title) => {
+  // A user can be granted access multiple times (in multiple groups that have access to the same forum)
+  return db
+    .query(accesses.queries.find_access, [semester_name, module_code, forum_title, user.id])
+    .then(data => data.rows.length >= 1);
+};
 
-exports.isProfessorInCourse = (user, semester_name, module_code) =>
-  db.query(
-    course_memberships.functions.is_member_in_course,
-    [user.id, semester_name, module_code, 'professor'],
-    (err, data) => {
-      if (err) {
-        throw new Error(err.message);
-      } else {
-        return data.rows[0].is_member_in_course;
-      }
-    }
-  );
+exports.isProfessorInCourse = (user, semester_name, module_code) => {
+  return db
+    .query(course_memberships.functions.is_member_in_course, [user.id, semester_name, module_code, 'professor'])
+    .then(data => data.rows[0].is_member_in_course);
+};
 
-exports.isTaInCourse = (user, semester_name, module_code) =>
-  db.query(
-    course_memberships.functions.is_member_in_course,
-    [user.id, semester_name, module_code, 'TA'],
-    (err, data) => {
-      if (err) {
-        throw new Error(err.message);
-      } else {
-        return data.rows[0].is_member_in_course;
-      }
-    }
-  );
+exports.isTaInCourse = (user, semester_name, module_code) => {
+  return db
+    .query(course_memberships.functions.is_member_in_course, [user.id, semester_name, module_code, 'TA'])
+    .then(data => data.rows[0].is_member_in_course);
+};

--- a/permissions/index.js
+++ b/permissions/index.js
@@ -1,11 +1,3 @@
-const users = require('./users');
-const semesters = require('./semesters');
-const modules = require('./modules');
-const courses = require('./courses');
-const groups = require('./groups');
-const forums = require('./forums');
-const accesses = require('./accesses');
-const threads = require('./threads');
 const log = require('../helpers/logging');
 
 const handleAccessDenied = (req, res) => {
@@ -15,8 +7,8 @@ const handleAccessDenied = (req, res) => {
   res.redirect('back');
 };
 
-const ensureAuthorised = funct => (req, res, next) => {
-  if (funct(req)) {
+const ensureAuthorised = funct => async (req, res, next) => {
+  if (await funct(req)) {
     next();
   } else {
     handleAccessDenied(req, res);
@@ -24,6 +16,5 @@ const ensureAuthorised = funct => (req, res, next) => {
 };
 
 module.exports = {
-  checkers: { ...users, ...semesters, ...modules, ...courses, ...groups, ...forums, ...accesses, ...threads },
   ensureAuthorised
 };

--- a/permissions/index.js
+++ b/permissions/index.js
@@ -7,11 +7,16 @@ const handleAccessDenied = (req, res) => {
   res.redirect('back');
 };
 
-const ensureAuthorised = funct => async (req, res, next) => {
-  if (await funct(req)) {
-    next();
-  } else {
-    handleAccessDenied(req, res);
+const ensureAuthorised = checkPermissions => async (req, res, next) => {
+  try {
+    if (await checkPermissions(req)) {
+      next();
+    } else {
+      handleAccessDenied(req, res);
+    }
+  } catch (err) {
+    log.error('An error occurred while checking for permissions.');
+    next(err);
   }
 };
 

--- a/permissions/replies.js
+++ b/permissions/replies.js
@@ -1,0 +1,28 @@
+const { passedAny, isAdmin, isProfessorInCourse, isTaInCourse } = require('./helpers');
+const { canShowThread } = require('./threads');
+
+function canCreateReply(user, semester_name, module_code, forum_title) {
+  return canShowThread(user, semester_name, module_code, forum_title);
+}
+
+function canUpdateReply(user, semester_name, module_code) {
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
+    isTaInCourse(user, semester_name, module_code)
+  );
+}
+
+function canDeleteReply(user, semester_name, module_code) {
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
+    isTaInCourse(user, semester_name, module_code)
+  );
+}
+
+module.exports = {
+  canCreateReply,
+  canUpdateReply,
+  canDeleteReply
+};

--- a/permissions/threads.js
+++ b/permissions/threads.js
@@ -1,6 +1,6 @@
 const { passedAny, isAdmin, isProfessorInCourse, isTaInCourse } = require('./helpers');
 
-function canEditThreads(user, semester_name, module_code) {
+function canEditThread(user, semester_name, module_code) {
   return passedAny(
     isAdmin(user),
     isProfessorInCourse(user, semester_name, module_code),
@@ -9,10 +9,14 @@ function canEditThreads(user, semester_name, module_code) {
 }
 
 function canDeleteThreads(user, semester_name, module_code) {
-  return canEditThreads(user, semester_name, module_code);
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
+    isTaInCourse(user, semester_name, module_code)
+  );
 }
 
 module.exports = {
-  canEditThreads,
+  canEditThread,
   canDeleteThreads
 };

--- a/permissions/threads.js
+++ b/permissions/threads.js
@@ -1,4 +1,13 @@
 const { passedAny, isAdmin, isProfessorInCourse, isTaInCourse } = require('./helpers');
+const { canShowForum } = require('./forums');
+
+function canShowThread(user, semester_name, module_code, forum_title) {
+  return canShowForum(user, semester_name, module_code, forum_title);
+}
+
+function canCreateThread(user, semester_name, module_code, forum_title) {
+  return canShowForum(user, semester_name, module_code, forum_title);
+}
 
 function canEditThread(user, semester_name, module_code) {
   return passedAny(
@@ -8,7 +17,7 @@ function canEditThread(user, semester_name, module_code) {
   );
 }
 
-function canDeleteThreads(user, semester_name, module_code) {
+function canDeleteThread(user, semester_name, module_code) {
   return passedAny(
     isAdmin(user),
     isProfessorInCourse(user, semester_name, module_code),
@@ -17,6 +26,8 @@ function canDeleteThreads(user, semester_name, module_code) {
 }
 
 module.exports = {
+  canShowThread,
+  canCreateThread,
   canEditThread,
-  canDeleteThreads
+  canDeleteThread
 };

--- a/permissions/threads.js
+++ b/permissions/threads.js
@@ -1,9 +1,9 @@
-const { isAdmin, isProfessorInCourse, isTaInCourse } = require('./helpers');
+const { passedAny, isAdmin, isProfessorInCourse, isTaInCourse } = require('./helpers');
 
 function canEditThreads(user, semester_name, module_code) {
-  return (
-    isAdmin(user) ||
-    isProfessorInCourse(user, semester_name, module_code) ||
+  return passedAny(
+    isAdmin(user),
+    isProfessorInCourse(user, semester_name, module_code),
     isTaInCourse(user, semester_name, module_code)
   );
 }

--- a/routes/courses.js
+++ b/routes/courses.js
@@ -4,7 +4,7 @@ const groups_routes = require('./groups');
 const forums_routes = require('./forums');
 const log = require('../helpers/logging');
 const { ensureAuthorised } = require('../permissions');
-const { canCreateCourse, canShowCourse, canUpdateCourse, canDeleteCourse } = require('../permissions').checkers;
+const { canCreateCourse, canShowCourse, canUpdateCourse, canDeleteCourse } = require('../permissions/courses');
 
 router.use((req, res, next) => {
   log.controller('Courses controller handling the request');

--- a/routes/forums.js
+++ b/routes/forums.js
@@ -9,8 +9,8 @@ const {
   canCreateForum,
   canUpdateForum,
   canDeleteForum,
-  canEditAccess
-} = require('../permissions').checkers;
+} = require('../permissions/forums');
+const { canEditAccess } = require('../permissions/accesses');
 
 router.use((req, res, next) => {
   log.controller('Forums controller handling the request');

--- a/routes/forums.js
+++ b/routes/forums.js
@@ -4,12 +4,7 @@ const accesses = require('../controllers/accesses_controller');
 const threads_routes = require('./threads');
 const log = require('../helpers/logging');
 const { ensureAuthorised } = require('../permissions');
-const {
-  canShowForum,
-  canCreateForum,
-  canUpdateForum,
-  canDeleteForum,
-} = require('../permissions/forums');
+const { canShowForum, canCreateForum, canUpdateForum, canDeleteForum } = require('../permissions/forums');
 const { canEditAccess } = require('../permissions/accesses');
 
 router.use((req, res, next) => {

--- a/routes/forums.js
+++ b/routes/forums.js
@@ -22,15 +22,15 @@ router.get(
   ensureAuthorised(req => canCreateForum(req.user, req.params.semester_name, req.params.module_code)),
   forums.new
 );
-router.get(
-  '/:title',
-  ensureAuthorised(req => canShowForum(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
-  forums.show
-);
 router.post(
   '/',
   ensureAuthorised(req => canCreateForum(req.user, req.params.semester_name, req.params.module_code)),
   forums.create
+);
+router.get(
+  '/:title',
+  ensureAuthorised(req => canShowForum(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  forums.show
 );
 router.delete(
   '/:title',
@@ -47,6 +47,8 @@ router.put(
   ensureAuthorised(req => canUpdateForum(req.user, req.params.semester_name, req.params.module_code)),
   forums.update
 );
+
+// Accesses
 router.get(
   '/:title/accesses',
   ensureAuthorised(req => canEditAccess(req.user, req.params.semester_name, req.params.module_code)),

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -5,7 +5,7 @@ const { ensureAuthorised } = require('../permissions');
 const { canShowGroup, canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissions/groups');
 
 router.use((req, res, next) => {
-  log.controller('groups controller handling the request');
+  log.controller('Groups controller handling the request');
   next();
 });
 
@@ -14,15 +14,15 @@ router.get(
   ensureAuthorised(req => canCreateGroup(req.user, req.params.semester_name, req.params.module_code)),
   groups.new
 );
-router.get(
-  '/:name',
-  ensureAuthorised(req => canShowGroup(req.user, req.params.semester_name, req.params.module_code, req.params.name)),
-  groups.show
-);
 router.post(
   '/',
   ensureAuthorised(req => canCreateGroup(req.user, req.params.semester_name, req.params.module_code)),
   groups.create
+);
+router.get(
+  '/:name',
+  ensureAuthorised(req => canShowGroup(req.user, req.params.semester_name, req.params.module_code, req.params.name)),
+  groups.show
 );
 router.delete(
   '/:name',

--- a/routes/groups.js
+++ b/routes/groups.js
@@ -2,7 +2,7 @@ const router = require('express').Router({ mergeParams: true });
 const groups = require('../controllers/groups_controller');
 const log = require('../helpers/logging');
 const { ensureAuthorised } = require('../permissions');
-const { canShowGroup, canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissions').checkers;
+const { canShowGroup, canCreateGroup, canUpdateGroup, canDeleteGroup } = require('../permissions/groups');
 
 router.use((req, res, next) => {
   log.controller('groups controller handling the request');

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,8 @@ const courses = require('./courses');
 const { ensureAuthenticated } = require('../auth/middleware');
 const log = require('../helpers/logging');
 const { ensureAuthorised } = require('../permissions');
-const { canAccessSemesters, canAccessModules } = require('../permissions').checkers;
+const { canAccessSemesters } = require('../permissions/semesters');
+const { canAccessModules } = require('../permissions/modules');
 
 // Root redirect
 router.get('/', (req, res) => {

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -9,5 +9,8 @@ router.use((req, res, next) => {
 
 router.get('/new', replies.new);
 router.post('/', replies.create);
+router.get('/:posted_at/edit', replies.edit);
+router.put('/:posted_at', replies.update);
+router.delete('/:posted_at', replies.delete);
 
 module.exports = router;

--- a/routes/replies.js
+++ b/routes/replies.js
@@ -1,16 +1,38 @@
 const router = require('express').Router({ mergeParams: true });
 const log = require('../helpers/logging');
 const replies = require('../controllers/replies_controller');
+const { ensureAuthorised } = require('../permissions');
+const { canCreateReply, canDeleteReply, canUpdateReply } = require('../permissions/replies');
 
 router.use((req, res, next) => {
   log.controller('Replies controller handling the request');
   next();
 });
 
-router.get('/new', replies.new);
-router.post('/', replies.create);
-router.get('/:posted_at/edit', replies.edit);
-router.put('/:posted_at', replies.update);
-router.delete('/:posted_at', replies.delete);
+router.get(
+  '/new',
+  ensureAuthorised(req => canCreateReply(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  replies.new
+);
+router.post(
+  '/',
+  ensureAuthorised(req => canCreateReply(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  replies.create
+);
+router.get(
+  '/:posted_at/edit',
+  ensureAuthorised(req => canUpdateReply(req.user, req.params.semester_name, req.params.module_code)),
+  replies.edit
+);
+router.put(
+  '/:posted_at',
+  ensureAuthorised(req => canUpdateReply(req.user, req.params.semester_name, req.params.module_code)),
+  replies.update
+);
+router.delete(
+  '/:posted_at',
+  ensureAuthorised(req => canDeleteReply(req.user, req.params.semester_name, req.params.module_code)),
+  replies.delete
+);
 
 module.exports = router;

--- a/routes/threads.js
+++ b/routes/threads.js
@@ -2,18 +2,44 @@ const router = require('express').Router({ mergeParams: true });
 const log = require('../helpers/logging');
 const threads = require('../controllers/threads_controller');
 const replies_route = require('./replies');
+const { ensureAuthorised } = require('../permissions');
+const { canShowThread, canCreateThread, canEditThread, canDeleteThread } = require('../permissions/threads');
 
 router.use((req, res, next) => {
   log.controller('Threads controller handling the request');
   next();
 });
 
-router.get('/new', threads.new);
-router.post('/', threads.create);
-router.get('/:created_at', threads.show);
-router.get('/:created_at/edit', threads.edit);
-router.put('/:created_at', threads.update);
-router.delete('/:created_at', threads.delete);
+router.get(
+  '/new',
+  ensureAuthorised(req => canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  threads.new
+);
+router.post(
+  '/',
+  ensureAuthorised(req => canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  threads.create
+);
+router.get(
+  '/:created_at',
+  ensureAuthorised(req => canShowThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  threads.show
+);
+router.get(
+  '/:created_at/edit',
+  ensureAuthorised(req => canEditThread(req.user, req.params.semester_name, req.params.module_code)),
+  threads.edit
+);
+router.put(
+  '/:created_at',
+  ensureAuthorised(req => canEditThread(req.user, req.params.semester_name, req.params.module_code)),
+  threads.update
+);
+router.delete(
+  '/:created_at',
+  ensureAuthorised(req => canDeleteThread(req.user, req.params.semester_name, req.params.module_code)),
+  threads.delete
+);
 
 // Nest replies routes within thread
 router.use('/:created_at/replies', replies_route);

--- a/routes/threads.js
+++ b/routes/threads.js
@@ -12,12 +12,16 @@ router.use((req, res, next) => {
 
 router.get(
   '/new',
-  ensureAuthorised(req => canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  ensureAuthorised(req =>
+    canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)
+  ),
   threads.new
 );
 router.post(
   '/',
-  ensureAuthorised(req => canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)),
+  ensureAuthorised(req =>
+    canCreateThread(req.user, req.params.semester_name, req.params.module_code, req.params.title)
+  ),
   threads.create
 );
 router.get(

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const users = require('../controllers/users_controller');
 const { ensureAuthorised } = require('../permissions');
-const { canIndexUsers, canDeleteUser, canUpdateUser } = require('../permissions').checkers;
+const { canIndexUsers, canDeleteUser, canUpdateUser } = require('../permissions/users');
 const log = require('../helpers/logging');
 
 router.use((req, res, next) => {

--- a/sql/accesses.js
+++ b/sql/accesses.js
@@ -1,9 +1,9 @@
 const accesses = {};
 
 accesses.queries = {
-  find_accesss:
-    'SELECT * FROM accesses A NATURAL JOIN group_memberships GM' +
-    'WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND user_id=4',
+  find_access:
+    'SELECT * FROM accesses A NATURAL JOIN group_memberships GM ' +
+    'WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND user_id=$4',
   get_group_names_by_forum:
     'SELECT group_name FROM accesses A WHERE A.semester_name = $1 AND A.module_code = $2 AND A.forum_title = $3'
 };

--- a/sql/course_memberships.js
+++ b/sql/course_memberships.js
@@ -1,7 +1,7 @@
 const course_memberships = {};
 
 course_memberships.queries = {
-  find_membership: 'SELECT * FROM course_memberships WHERE semester_name = $1 AND module_code=$2 AND user_id=$3'
+  find_membership: 'SELECT * FROM course_memberships WHERE semester_name=$1 AND module_code=$2 AND user_id=$3'
 };
 
 course_memberships.functions = {

--- a/sql/replies.js
+++ b/sql/replies.js
@@ -1,12 +1,16 @@
 const replies = {};
 
 replies.queries = {
-  count_replies_of_thread:
-    'SELECT COUNT(*) FROM replies WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND thread_created_at=$4',
+  find_reply:
+    'SELECT * FROM replies WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND thread_created_at=$4 AND created_at=$5',
   get_replies_of_forum:
     'SELECT * FROM replies WHERE semester_name=$1 AND module_code=$2 and forum_title=$3 AND thread_created_at=$4',
   create_reply:
-    'INSERT INTO replies (semester_name, module_code, forum_title, thread_created_at, created_at, content, author_id) VALUES ($1, $2, $3, $4, $5, $6, $7)'
+    'INSERT INTO replies (semester_name, module_code, forum_title, thread_created_at, created_at, content, author_id) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+  update_reply:
+    'UPDATE replies SET content=$6 WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND thread_created_at=$4 AND created_at=$5',
+  delete_reply:
+    'DELETE FROM replies WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND thread_created_at=$4 AND created_at=$5'
 };
 
 module.exports = replies;

--- a/sql/replies.js
+++ b/sql/replies.js
@@ -3,8 +3,10 @@ const replies = {};
 replies.queries = {
   find_reply:
     'SELECT * FROM replies WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND thread_created_at=$4 AND created_at=$5',
-  get_replies_of_forum:
-    'SELECT * FROM replies WHERE semester_name=$1 AND module_code=$2 and forum_title=$3 AND thread_created_at=$4',
+  get_replies_of_thread:
+    'SELECT r.created_at, r.content, r.semester_name, r.module_code, r.forum_title, r.thread_created_at, u.name AS author_name ' +
+    'FROM replies r LEFT JOIN users u ON r.author_id=u.id ' +
+    'WHERE semester_name=$1 AND module_code=$2 and forum_title=$3 AND thread_created_at=$4',
   create_reply:
     'INSERT INTO replies (semester_name, module_code, forum_title, thread_created_at, created_at, content, author_id) VALUES ($1, $2, $3, $4, $5, $6, $7)',
   update_reply:

--- a/sql/threads.js
+++ b/sql/threads.js
@@ -6,7 +6,7 @@ threads.queries = {
     'SELECT t.semester_name AS semester_name, t.module_code AS module_code, t.forum_title AS forum_title, u.name AS author_name, ' +
     't.created_at AS created_at, t.title AS title, t.content AS content, COUNT(r.created_at) AS replies_count, MAX(r.created_at) AS latest_reply_time ' +
     'FROM threads t LEFT JOIN users u ON t.author_id=u.id ' +
-    'LEFT JOIN replies r ON t.semester_name=r.semester_name AND t.module_code=r.module_code AND t.forum_title=r.forum_title ' +
+    'LEFT JOIN replies r ON t.semester_name=r.semester_name AND t.module_code=r.module_code AND t.forum_title=r.forum_title AND t.created_at=r.thread_created_at ' +
     'WHERE t.semester_name=$1 AND t.module_code=$2 AND t.forum_title=$3 ' +
     'GROUP BY(t.semester_name, t.module_code, t.forum_title, t.created_at, u.name)',
   create_thread:

--- a/sql/threads.js
+++ b/sql/threads.js
@@ -1,7 +1,10 @@
 const threads = {};
 
 threads.queries = {
-  find_thread: 'SELECT * FROM threads WHERE semester_name=$1 AND module_code=$2 AND forum_title=$3 AND created_at=$4',
+  find_thread_with_author_name:
+    'SELECT t.created_at, t.title, t.content, u.name AS author_name, t.semester_name, t.module_code, t.forum_title ' +
+    'FROM threads t LEFT JOIN users u ON t.author_id=u.id ' +
+    'WHERE t.semester_name=$1 AND t.module_code=$2 AND t.forum_title=$3 AND t.created_at=$4',
   get_threads_info_by_forum:
     'SELECT t.semester_name AS semester_name, t.module_code AS module_code, t.forum_title AS forum_title, u.name AS author_name, ' +
     't.created_at AS created_at, t.title AS title, t.content AS content, COUNT(r.created_at) AS replies_count, MAX(r.created_at) AS latest_reply_time ' +

--- a/views/course.ejs
+++ b/views/course.ejs
@@ -7,7 +7,7 @@
   <p><%= course.description %></p>
   <hr class="mt-5 mb-5" />
   <h2>
-    Groups <% if (canCreateGroup(user, course.semester_name, course.module_code)) { %>
+    Groups <% if (permissions.can_create_group) { %>
     <div class="float-right" style="display: inline">
       <a href="<%= groupNewPath(course.semester_name, course.module_code) %>" class="btn btn-outline-primary">
         <i class="far fa-plus"></i>
@@ -28,18 +28,17 @@
       <tr>
         <td><%= groups[i].name%></td>
         <td>
-          <% if (canShowGroup(user, course.semester_name, course.module_code, groups[i].name)) { %>
           <a href="<%= groupPath(course.semester_name, course.module_code, groups[i].name) %>" class="btn btn-primary">
             <i class="far fa-eye"></i>
           </a>
-          <% } %> <% if (canUpdateGroup(user, course.semester_name, course.module_code)) { %>
+          <% if (permissions.can_update_group) { %>
           <a
             href="<%= groupEditPath(course.semester_name, course.module_code, groups[i].name) %>"
             class="btn btn-success"
           >
             <i class="fas fa-edit"></i>
           </a>
-          <% } %> <% if (canDeleteGroup(user, course.semester_name, course.module_code)) { %>
+          <% } %> <% if (permissions.can_delete_group) { %>
           <%-partial('./partials/deleteButton',{ action: groupPath(course.semester_name, course.module_code,
           groups[i].name) })%> <% } %>
         </td>
@@ -49,7 +48,7 @@
   </table>
 
   <h2>
-    Forums <% if (canCreateForum(user, course.semester_name, course.module_code)) { %>
+    Forums <% if (permissions.can_create_forum) { %>
     <div class="float-right" style="display: inline">
       <a href="<%= forumNewPath(course.semester_name, course.module_code) %>" class="btn btn-outline-primary">
         <i class="far fa-plus"></i>
@@ -70,18 +69,17 @@
       <tr>
         <td><%= forums[i].title%></td>
         <td>
-          <% if (canShowForum(user, course.semester_name, course.module_code, forums[i].title)) { %>
           <a href="<%= forumPath(course.semester_name, course.module_code, forums[i].title) %>" class="btn btn-primary">
             <i class="far fa-eye"></i>
           </a>
-          <% } %> <% if (canUpdateForum(user, course.semester_name, course.module_code)) { %>
+          <% if (permissions.can_update_forum) { %>
           <a
             href="<%= forumEditPath(course.semester_name, course.module_code, forums[i].title) %>"
             class="btn btn-success"
           >
             <i class="fas fa-edit"></i>
           </a>
-          <% } %> <% if (canDeleteForum(user, course.semester_name, course.module_code)) { %>
+          <% } %> <% if (permissions.can_delete_forum) { %>
           <%-partial('./partials/deleteButton',{ action: forumPath(course.semester_name, course.module_code,
           forums[i].title) })%> <% } %>
         </td>

--- a/views/courses.ejs
+++ b/views/courses.ejs
@@ -1,7 +1,7 @@
 <% layout('layout') -%>
 <div class="container">
   <h1 class="mt-3 mb-3"><%= title %>
-    <% if (canCreateCourse(user)) { %>
+    <% if (permissions.can_create_course) { %>
     <div class="float-right" style="display: inline">
       <a href="<%= courseNewPath()%>" class="btn btn-outline-primary">
         <i class="far fa-plus"></i>
@@ -29,18 +29,14 @@
         <td><%= data[i].title%></td>
         <td><%= data[i].credits%></td>
         <td>
-          <% if (canShowCourse(user, data[i].semester_name, data[i].module_code)) { %>
           <a href="<%= coursePath(data[i].semester_name, data[i].module_code) %>" class="btn btn-primary">
             <i class="far fa-eye"></i>
           </a>
-          <% } %>
-          <% if (canUpdateCourse(user, data[i].semester_name, data[i].module_code)) { %>
           <a href="<%= courseEditPath(data[i].semester_name, data[i].module_code)%>"
             class="btn btn-success">
             <i class="fas fa-edit"></i>
           </a>
-          <% } %>
-          <% if (canDeleteCourse(user)) { %>
+          <% if (permissions.can_delete_course) { %>
           <%-partial('./partials/deleteButton',{ action: coursePath(data[i].semester_name, data[i].module_code) })%>
           <% } %>
         </td>

--- a/views/forum.ejs
+++ b/views/forum.ejs
@@ -5,7 +5,8 @@
   <h2><small class="text-muted"><%= course.semester_name %></small></h2>
   <h2>Forum: <%= forum.title %></h2>
   <p class="h6">
-    Accessible by the following group(s): <% if (canEditAccess(user, course.semester_name, course.module_code)) { %>
+    Accessible by the following group(s):
+    <% if (permissions.can_edit_access) { %>
       <a href="<%= accessesPath(course.semester_name, course.module_code, forum.title) %>">
         <i class="fa fa-pencil"></i>
       </a>
@@ -54,12 +55,12 @@
           <a href="<%= threadPath(course.semester_name, course.module_code, forum.title, threads[i].created_at) %>" class="btn btn-primary">
             <i class="far fa-eye"></i>
           </a>
-          <% if (canEditThreads(user, course.semester_name, course.module_code)) { %>
+          <% if (permissions.can_edit_thread) { %>
             <a href="<%= threadEditPath(course.semester_name, course.module_code, forum.title, threads[i].created_at) %>" class="btn btn-success">
               <i class="fas fa-edit"></i>
             </a>
           <% } %>
-          <% if (canDeleteThreads(user, course.semester_name, course.module_code)) { %>
+          <% if (permissions.can_delete_thread) { %>
             <%- partial('./partials/deleteButton', { action: threadPath(course.semester_name, course.module_code, forum.title, threads[i].created_at) })%>
           <% } %>
         </td>

--- a/views/replyForm.ejs
+++ b/views/replyForm.ejs
@@ -13,15 +13,18 @@
         </div>
     </div>
 
-    <h2 class="text-center mt-3 mb-3">New Reply</h2>
+    <h2 class="text-center mt-3 mb-3"><%= reply ? 'Edit' : 'New' %> Reply</h2>
     <%- partial('./partials/messages', { messages: flash() }) %>
     <form id="thread_form"
-          action="<%= repliesPath(course.semester_name, course.module_code, forum.title, thread.created_at) %>"
+          action="<%= reply ? replyPath(course.semester_name, course.module_code, forum.title, thread.created_at, reply.created_at) : repliesPath(course.semester_name, course.module_code, forum.title, thread.created_at) %>"
           role="form" method="POST">
+        <% if (reply) { %>
+            <input type="hidden" name="_method" value="PUT"/>
+        <% } %>
         <div class="form-group">
             <label for="content">Your reply</label>
-            <textarea class="form-control" id="content" name="content" required="required"></textarea>
+            <textarea class="form-control" id="content" name="content" required="required"><%= reply ? reply.content : '' %></textarea>
         </div>
-        <button type="submit" class="btn btn-primary">Reply</button>
+        <button type="submit" class="btn btn-primary"><%= reply ? 'Edit reply' : 'Reply' %></button>
     </form>
 </div>

--- a/views/thread.ejs
+++ b/views/thread.ejs
@@ -1,9 +1,12 @@
 <% layout('layout') -%>
 <div class="container mt-3">
     <%- partial('./partials/messages', { messages: flash() }) %>
-    <h1 class="mt-3 mb-3"><a href="<%= coursePath(course.semester_name, course.module_code) %>"><%= course.module_code %> <%= course.title %></a></h1>
+    <h1 class="mt-3 mb-3"><a
+                href="<%= coursePath(course.semester_name, course.module_code) %>"><%= course.module_code %> <%= course.title %></a>
+    </h1>
     <h2><small class="text-muted"><%= course.semester_name %></small></h2>
-    <h2>Forum: <a href="<%= forumPath(course.semester_name, course.module_code, forum.title) %>"><%= forum.title %></a></h2>
+    <h2>Forum: <a href="<%= forumPath(course.semester_name, course.module_code, forum.title) %>"><%= forum.title %></a>
+    </h2>
     <div class="card mt-5">
         <div class="card-body">
             <h3 class="card-title mb-4"><%= thread.title %></h3>
@@ -30,6 +33,11 @@
                 <p class="card-text"><%= replies[i].content %></p>
                 <p class="card-text text-right">Posted by <%= replies[i].author_name || '[deleted user]' %>
                     on <%= timestampToDisplayedForm(replies[i].created_at) %></p>
+                <a href="<%= replyEditPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) %>"
+                   class="btn btn-success">
+                    <i class="fa fa-edit"></i>
+                </a>
+                <%- partial('./partials/deleteButton', { action: replyPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) }) %>
             </div>
         </div>
     <% } %>

--- a/views/thread.ejs
+++ b/views/thread.ejs
@@ -3,7 +3,6 @@
     <%- partial('./partials/messages', { messages: flash() }) %>
     <h1 class="mt-3 mb-3"><a href="<%= coursePath(course.semester_name, course.module_code) %>"><%= course.module_code %> <%= course.title %></a></h1>
     <h2><small class="text-muted"><%= course.semester_name %></small></h2>
-    <h2><small class="text-muted"><%= course.semester_name %></small></h2>
     <h2>Forum: <a href="<%= forumPath(course.semester_name, course.module_code, forum.title) %>"><%= forum.title %></a></h2>
     <div class="card mt-5">
         <div class="card-body">

--- a/views/thread.ejs
+++ b/views/thread.ejs
@@ -19,13 +19,15 @@
 
     <h2>
         Replies
-        <div class="float-right" style="display: inline">
-            <a href="<%= replyNewPath(course.semester_name, course.module_code, forum.title, thread.created_at) %>"
-               class="btn btn-outline-primary">
-                <i class="far fa-plus"></i>
-                New Reply
-            </a>
-        </div>
+        <% if (permissions.can_create_reply) { %>
+            <div class="float-right" style="display: inline">
+                <a href="<%= replyNewPath(course.semester_name, course.module_code, forum.title, thread.created_at) %>"
+                   class="btn btn-outline-primary">
+                    <i class="far fa-plus"></i>
+                    New Reply
+                </a>
+            </div>
+        <% } %>
     </h2>
     <% for (let i = 0; i < replies.length; i++) { %>
         <div class="card mt-5">
@@ -33,11 +35,15 @@
                 <p class="card-text"><%= replies[i].content %></p>
                 <p class="card-text text-right">Posted by <%= replies[i].author_name || '[deleted user]' %>
                     on <%= timestampToDisplayedForm(replies[i].created_at) %></p>
-                <a href="<%= replyEditPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) %>"
-                   class="btn btn-success">
-                    <i class="fa fa-edit"></i>
-                </a>
-                <%- partial('./partials/deleteButton', { action: replyPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) }) %>
+                <% if (permissions.can_update_reply) { %>
+                    <a href="<%= replyEditPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) %>"
+                       class="btn btn-success">
+                        <i class="fa fa-edit"></i>
+                    </a>
+                <% } %>
+                <% if (permissions.can_delete_reply) { %>
+                    <%- partial('./partials/deleteButton', { action: replyPath(course.semester_name, course.module_code, forum.title, thread.created_at, replies[i].created_at) }) %>
+                <% } %>
             </div>
         </div>
     <% } %>


### PR DESCRIPTION
Due to the eccentricities of JavaScript, once a method is async all the methods that call it must be async as well. DB query methods are async, forcing our permission checkers to be async as well. 

Async functions are perfectly fine for use as middleware in the router, but cannot be used in views because ejs does not support async js.

This means our old way of directly calling the permission checkers in the view does not work. To work around this, call the necessary permission checkers and construct a `permissions` object in the controller. This object should hold all the necessary permissions the view needs. The controller should pass this object into the view as a local, and the view can get the boolean values directly. For an example, see `courses_controller#show`.